### PR TITLE
Removed automatic addition of label in Github IsssueAppenders.

### DIFF
--- a/core/src/main/java/com/github/taucher2003/appenders/core/github/IssueAppender.java
+++ b/core/src/main/java/com/github/taucher2003/appenders/core/github/IssueAppender.java
@@ -33,7 +33,6 @@ public class IssueAppender extends AbstractGithubAppender {
     protected List<String> labels = new ArrayList<>();
 
     public IssueAppender() {
-        labels.add("logger");
     }
 
     @Override

--- a/core/src/main/java/com/github/taucher2003/appenders/core/github/IssueAppender.java
+++ b/core/src/main/java/com/github/taucher2003/appenders/core/github/IssueAppender.java
@@ -32,9 +32,6 @@ public class IssueAppender extends AbstractGithubAppender {
 
     protected List<String> labels = new ArrayList<>();
 
-    public IssueAppender() {
-    }
-
     @Override
     protected void startInternally() {
     }


### PR DESCRIPTION
Closes #43

As mentioned in issue the problem was the automatic addition of "loggers" label, 
it has been removed from being added every time.