### PR TITLE
Switch from ExecutorService to ForkJoinPool

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Run Integration Tests
         run: |
           source ../.github/workflows/utils.sh
-          retry yarn test:ci
+          run_timed_command yarn test:ci
         working-directory: ./integration-tests
       - name: Upload Integration Test Results
         if: always()

--- a/.github/workflows/ci_merged_result.yml
+++ b/.github/workflows/ci_merged_result.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Run Integration Tests
         run: |
           source ../.github/workflows/utils.sh
-          retry yarn test:ci
+          run_timed_command yarn test:ci
         working-directory: ./integration-tests
       - name: Upload Integration Test Results
         if: always()

--- a/core/src/main/java/com/github/taucher2003/appenders/core/AbstractAppender.java
+++ b/core/src/main/java/com/github/taucher2003/appenders/core/AbstractAppender.java
@@ -42,7 +42,7 @@ public abstract class AbstractAppender {
     private static void shutdown() {
         INSTANCES.forEach(AbstractAppender::stop);
         //noinspection ResultOfMethodCallIgnored // we only need the side effect
-        FORK_JOIN_POOL.awaitQuiescence(1, TimeUnit.NANOSECONDS);
+        FORK_JOIN_POOL.awaitQuiescence(1, TimeUnit.MILLISECONDS);
     }
 
     private int flushInterval = 5;

--- a/core/src/main/java/com/github/taucher2003/appenders/core/AbstractAppender.java
+++ b/core/src/main/java/com/github/taucher2003/appenders/core/AbstractAppender.java
@@ -42,7 +42,7 @@ public abstract class AbstractAppender {
     private static void shutdown() {
         INSTANCES.forEach(AbstractAppender::stop);
         //noinspection ResultOfMethodCallIgnored // we only need the side effect
-        FORK_JOIN_POOL.awaitQuiescence(1, TimeUnit.SECONDS);
+        FORK_JOIN_POOL.awaitQuiescence(10, TimeUnit.SECONDS);
     }
 
     private int flushInterval = 5;

--- a/core/src/main/java/com/github/taucher2003/appenders/core/AbstractAppender.java
+++ b/core/src/main/java/com/github/taucher2003/appenders/core/AbstractAppender.java
@@ -42,7 +42,7 @@ public abstract class AbstractAppender {
     private static void shutdown() {
         INSTANCES.forEach(AbstractAppender::stop);
         //noinspection ResultOfMethodCallIgnored // we only need the side effect
-        FORK_JOIN_POOL.awaitQuiescence(1, TimeUnit.MILLISECONDS);
+        FORK_JOIN_POOL.awaitQuiescence(1, TimeUnit.NANOSECONDS);
     }
 
     private int flushInterval = 5;

--- a/core/src/main/java/com/github/taucher2003/appenders/core/AbstractAppender.java
+++ b/core/src/main/java/com/github/taucher2003/appenders/core/AbstractAppender.java
@@ -43,6 +43,8 @@ public abstract class AbstractAppender {
         INSTANCES.forEach(AbstractAppender::stop);
         //noinspection ResultOfMethodCallIgnored // we only need the side effect
         FORK_JOIN_POOL.awaitQuiescence(1, TimeUnit.NANOSECONDS);
+        while(FORK_JOIN_POOL.getRunningThreadCount() > 0 || FORK_JOIN_POOL.getQueuedSubmissionCount() > 0) {
+        }
     }
 
     private int flushInterval = 5;

--- a/core/src/main/java/com/github/taucher2003/appenders/core/AbstractAppender.java
+++ b/core/src/main/java/com/github/taucher2003/appenders/core/AbstractAppender.java
@@ -42,7 +42,7 @@ public abstract class AbstractAppender {
     private static void shutdown() {
         INSTANCES.forEach(AbstractAppender::stop);
         //noinspection ResultOfMethodCallIgnored // we only need the side effect
-        FORK_JOIN_POOL.awaitQuiescence(1, TimeUnit.NANOSECONDS);
+        FORK_JOIN_POOL.awaitQuiescence(10, TimeUnit.NANOSECONDS);
     }
 
     private int flushInterval = 5;

--- a/core/src/main/java/com/github/taucher2003/appenders/core/AbstractAppender.java
+++ b/core/src/main/java/com/github/taucher2003/appenders/core/AbstractAppender.java
@@ -42,7 +42,7 @@ public abstract class AbstractAppender {
     private static void shutdown() {
         INSTANCES.forEach(AbstractAppender::stop);
         //noinspection ResultOfMethodCallIgnored // we only need the side effect
-        FORK_JOIN_POOL.awaitQuiescence(10, TimeUnit.SECONDS);
+        FORK_JOIN_POOL.awaitQuiescence(1, TimeUnit.NANOSECONDS);
     }
 
     private int flushInterval = 5;

--- a/core/src/main/java/com/github/taucher2003/appenders/core/AbstractAppender.java
+++ b/core/src/main/java/com/github/taucher2003/appenders/core/AbstractAppender.java
@@ -42,7 +42,7 @@ public abstract class AbstractAppender {
     private static void shutdown() {
         INSTANCES.forEach(AbstractAppender::stop);
         //noinspection ResultOfMethodCallIgnored // we only need the side effect
-        FORK_JOIN_POOL.awaitQuiescence(10, TimeUnit.NANOSECONDS);
+        FORK_JOIN_POOL.awaitQuiescence(1, TimeUnit.SECONDS);
     }
 
     private int flushInterval = 5;

--- a/core/src/main/java/com/github/taucher2003/appenders/core/discord/BotAppender.java
+++ b/core/src/main/java/com/github/taucher2003/appenders/core/discord/BotAppender.java
@@ -97,7 +97,7 @@ public class BotAppender extends AbstractDiscordAppender {
 
     @Override
     protected void stopInternally() {
-        discordRequester.shutdown();
+        // no-op
     }
 
     // ---- Setters

--- a/integration-tests/test/task/log4j-gitlab-commentingissues.spec.js
+++ b/integration-tests/test/task/log4j-gitlab-commentingissues.spec.js
@@ -43,28 +43,27 @@ describe("GitLab Commenting Issue Appender for Log4J", () => {
     it("Fetches Issues before creating issue", async () => {
         const mock = jest.fn();
         await execute("GitLab-CommentingIssue", mock, log4j);
-        expect(mock.mock.calls[0][1]).toEqual("Fetched Issues");
+        expect(mock.mock.calls.filter(s => s[1] === "Fetched Issues").length).toEqual(3);
     }, 60000);
 
     it("Creates comments for existing issue", async () => {
         const mock = jest.fn();
         await execute("GitLab-CommentingIssue", mock, log4j);
-        expect(mock.mock.calls[1][1]).toEqual("Commented on Issue");
-        expect(mock.mock.calls[3][1]).toEqual("Commented on Issue");
+        expect(mock.mock.calls.filter(s => s[1] === "Commented on Issue").length).toEqual(2);
     }, 60000);
 
     it("Creates issue for non existing issue", async () => {
         const mock = jest.fn();
         await execute("GitLab-CommentingIssue", mock, log4j);
-        expect(mock.mock.calls[5][1]).toEqual("Created Issue");
+        expect(mock.mock.calls.filter(s => s[1] === "Created Issue").length).toEqual(1);
     }, 60000);
 
     it("Calls Rest API with valid body", async () => {
         const mock = jest.fn();
         await execute("GitLab-CommentingIssue", mock, log4j);
-        expect(mock.mock.calls[1][0].body).toEqual({
+        expect(mock.mock.calls.find(c => c[1] === "Commented on Issue")[0].body).toEqual({
             body: expect.any(String),
             confidential: false
-        })
+        });
     }, 60000);
 })

--- a/integration-tests/test/task/log4j-gitlab-commentingissues.spec.js
+++ b/integration-tests/test/task/log4j-gitlab-commentingissues.spec.js
@@ -49,6 +49,7 @@ describe("GitLab Commenting Issue Appender for Log4J", () => {
     it("Creates comments for existing issue", async () => {
         const mock = jest.fn();
         await execute("GitLab-CommentingIssue", mock, log4j);
+        console.log(mock.mock.calls)
         expect(mock.mock.calls.filter(s => s[1] === "Commented on Issue").length).toEqual(2);
     }, 60000);
 

--- a/integration-tests/test/task/logback-github-commentingissues.spec.js
+++ b/integration-tests/test/task/logback-github-commentingissues.spec.js
@@ -45,27 +45,26 @@ describe("GitHub Commenting Issue Appender for Logback", () => {
     it("Fetches Issues before creating issue", async () => {
         const mock = jest.fn();
         await execute("GitHub-CommentingIssue", mock, logback);
-        expect(mock.mock.calls[0][1]).toEqual("Fetched Issues");
+        expect(mock.mock.calls.filter(s => s[1] === "Fetched Issues").length).toEqual(3);
     }, 60000);
 
     it("Creates comments for existing issue", async () => {
         const mock = jest.fn();
         await execute("GitHub-CommentingIssue", mock, logback);
-        expect(mock.mock.calls[1][1]).toEqual("Commented on Issue");
-        expect(mock.mock.calls[3][1]).toEqual("Commented on Issue");
+        expect(mock.mock.calls.filter(s => s[1] === "Commented on Issue").length).toEqual(2);
     }, 60000);
 
     it("Creates issue for non existing issue", async () => {
         const mock = jest.fn();
         await execute("GitHub-CommentingIssue", mock, logback);
-        expect(mock.mock.calls[5][1]).toEqual("Created Issue");
+        expect(mock.mock.calls.filter(s => s[1] === "Created Issue").length).toEqual(1);
     }, 60000);
 
     it("Calls Rest API with valid body", async () => {
         const mock = jest.fn();
         await execute("GitHub-CommentingIssue", mock, logback);
-        expect(mock.mock.calls[1][0].body).toEqual({
+        expect(mock.mock.calls.find(c => c[1] === "Commented on Issue")[0].body).toEqual({
             body: expect.any(String)
-        })
+        });
     }, 60000);
 })

--- a/integration-tests/test/task/logback-gitlab-commentingissues.spec.js
+++ b/integration-tests/test/task/logback-gitlab-commentingissues.spec.js
@@ -43,28 +43,27 @@ describe("GitLab Commenting Issue Appender for Logback", () => {
     it("Fetches Issues before creating issue", async () => {
         const mock = jest.fn();
         await execute("GitLab-CommentingIssue", mock, logback);
-        expect(mock.mock.calls[0][1]).toEqual("Fetched Issues");
+        expect(mock.mock.calls.filter(s => s[1] === "Fetched Issues").length).toEqual(3);
     }, 60000);
 
     it("Creates comments for existing issue", async () => {
         const mock = jest.fn();
         await execute("GitLab-CommentingIssue", mock, logback);
-        expect(mock.mock.calls[1][1]).toEqual("Commented on Issue");
-        expect(mock.mock.calls[3][1]).toEqual("Commented on Issue");
+        expect(mock.mock.calls.filter(s => s[1] === "Commented on Issue").length).toEqual(2);
     }, 60000);
 
     it("Creates issue for non existing issue", async () => {
         const mock = jest.fn();
         await execute("GitLab-CommentingIssue", mock, logback);
-        expect(mock.mock.calls[5][1]).toEqual("Created Issue");
+        expect(mock.mock.calls.filter(s => s[1] === "Created Issue").length).toEqual(1);
     }, 60000);
 
     it("Calls Rest API with valid body", async () => {
         const mock = jest.fn();
         await execute("GitLab-CommentingIssue", mock, logback);
-        expect(mock.mock.calls[1][0].body).toEqual({
+        expect(mock.mock.calls.find(c => c[1] === "Commented on Issue")[0].body).toEqual({
             body: expect.any(String),
             confidential: false
-        })
+        });
     }, 60000);
 })

--- a/integration-tests/test/task/runner.js
+++ b/integration-tests/test/task/runner.js
@@ -35,7 +35,7 @@ module.exports.execute = (test, jestFn, {framework, configName}) => {
     return startMockServer(test, jestFn).then((server) => {
         const childProcess = spawn("java", [`com.github.taucher2003.appenders.it.${framework}.LogMessageSender`], {
             cwd: `${framework}-it/target`,
-            timeout: 10000
+            timeout: 50000
         });
 
         childProcess.stdout.on('data', data => console.info(`${data}`));

--- a/integration-tests/test/task/runner.js
+++ b/integration-tests/test/task/runner.js
@@ -45,7 +45,7 @@ module.exports.execute = (test, jestFn, {framework, configName}) => {
             childProcess.on('close', () => {
                 server.close();
                 removeConfig(framework, configName);
-                setTimeout(resolve, 5000);
+                setTimeout(resolve, 5);
             })
         })
     })

--- a/log4j/src/main/java/com/github/taucher2003/appenders/log4j/discord/Log4JBotAppender.java
+++ b/log4j/src/main/java/com/github/taucher2003/appenders/log4j/discord/Log4JBotAppender.java
@@ -60,7 +60,7 @@ public final class Log4JBotAppender extends AbstractLog4JDiscordAppender<BotAppe
             @PluginAttribute("ignoreExceptions") boolean ignoreExceptions,
             @PluginAttribute(value = "token", sensitive = true) String token,
             @PluginAttribute(value = "channelId") String channelId,
-            @PluginAttribute(value = "apiHost") String apiHost,
+            @PluginAttribute(value = "apiHost", defaultString = "https://discord.com/api/v9") String apiHost,
             @PluginElement("Filters") Filter filter
     ) {
         if (name == null) {

--- a/utils/src/main/java/com/github/taucher2003/appenders/utils/WebRequestExecutor.java
+++ b/utils/src/main/java/com/github/taucher2003/appenders/utils/WebRequestExecutor.java
@@ -87,11 +87,11 @@ public abstract class WebRequestExecutor {
         long retryAfter = bucket.getRetryAfter();
         long resetIn = bucket.getResetAt() - System.currentTimeMillis();
         if (retryAfter > 0 || resetIn > 0) {
-            LOGGER.debug("Delaying queue execution for {}ms ({} in queue)", Math.max(retryAfter, resetIn), requests.size());
+            LOGGER.debug(selfIgnoringMarker, "Delaying queue execution for {}ms ({} in queue)", Math.max(retryAfter, resetIn), requests.size());
             try {
                 Thread.sleep(Math.max(retryAfter, resetIn));
             } catch (InterruptedException e) {
-                LOGGER.warn("Failed to delay queue execution", e);
+                LOGGER.warn(selfIgnoringMarker, "Failed to delay queue execution", e);
             }
         }
         executorService.execute(this::executeQueue);

--- a/utils/src/main/java/com/github/taucher2003/appenders/utils/WebRequestExecutor.java
+++ b/utils/src/main/java/com/github/taucher2003/appenders/utils/WebRequestExecutor.java
@@ -98,6 +98,7 @@ public abstract class WebRequestExecutor {
     }
 
     private synchronized void executeQueue() {
+        currentQueueExecution.set(true);
         while (!requests.isEmpty()) {
             if (bucket.isRatelimit()) {
                 delayQueue();

--- a/utils/src/main/java/com/github/taucher2003/appenders/utils/WebRequester.java
+++ b/utils/src/main/java/com/github/taucher2003/appenders/utils/WebRequester.java
@@ -1,6 +1,6 @@
 /*
  *
- *  Copyright 2021 Niklas van Schrick and the contributors of the Appenders Project
+ *  Copyright 2022 Niklas van Schrick and the contributors of the Appenders Project
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -53,12 +53,5 @@ public class WebRequester {
         }
         future.completeExceptionally(new RejectedExecutionException("Request has not been added to queue"));
         return future;
-    }
-
-    /**
-     * Shuts down the underlying {@link WebRequestExecutor}
-     */
-    public void shutdown() {
-        executor.shutdown();
     }
 }


### PR DESCRIPTION
The switch from ExecutorService to ForkJoinPool takes care of the shutdown as there are no dangling threads from our ExecutorService which block the shutdown

Fixes #22